### PR TITLE
fix(theme): use CMS theme colors in contact form and calendar

### DIFF
--- a/src/components/CVPageClient.tsx
+++ b/src/components/CVPageClient.tsx
@@ -1609,10 +1609,13 @@ export function CVPageClient({
                 {contactTab === 'message' &&
                   showContactForm &&
                   turnstileSiteKey && (
-                    <ContactForm turnstileSiteKey={turnstileSiteKey} />
+                    <ContactForm
+                      turnstileSiteKey={turnstileSiteKey}
+                      colors={colors}
+                    />
                   )}
                 {contactTab === 'schedule' && showCalendar && calLink && (
-                  <CalEmbed calLink={calLink} />
+                  <CalEmbed calLink={calLink} colors={colors} />
                 )}
               </motion.div>
             )}

--- a/src/components/contact/CalEmbed.tsx
+++ b/src/components/contact/CalEmbed.tsx
@@ -2,10 +2,13 @@
 
 import { useEffect, useState } from 'react'
 import { Calendar, ExternalLink, Loader2 } from 'lucide-react'
+import type { ThemeColors } from './ContactForm'
 
 interface CalEmbedProps {
   /** Cal.com username or booking link */
   calLink: string
+  /** Theme colors from CMS config */
+  colors: ThemeColors
   /** Optional specific event type slug */
   eventType?: string
   /** Hide branding (requires paid plan) */
@@ -20,6 +23,7 @@ interface CalEmbedProps {
  */
 export function CalEmbed({
   calLink,
+  colors,
   eventType,
   hideBranding = false,
 }: CalEmbedProps) {
@@ -69,16 +73,28 @@ export function CalEmbed({
   }, [fullCalLink, hideBranding])
 
   return (
-    <div className="rounded-xl border border-[var(--color-border)] overflow-hidden bg-[var(--background)]">
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: `1px solid ${colors.border}`, background: colors.bg }}
+    >
       {/* Terminal Header */}
-      <div className="flex items-center justify-between px-4 py-3 bg-[var(--surface)] border-b border-[var(--color-border)]">
+      <div
+        className="flex items-center justify-between px-4 py-3"
+        style={{
+          background: colors.surface,
+          borderBottom: `1px solid ${colors.border}`,
+        }}
+      >
         <div className="flex items-center gap-2">
           <div className="flex gap-1.5">
             <span className="w-3 h-3 rounded-full bg-red-500" />
             <span className="w-3 h-3 rounded-full bg-yellow-500" />
             <span className="w-3 h-3 rounded-full bg-green-500" />
           </div>
-          <span className="text-sm text-[var(--text-muted)] font-mono">
+          <span
+            className="text-sm font-mono"
+            style={{ color: colors.textMuted }}
+          >
             schedule-call.sh
           </span>
         </div>
@@ -86,7 +102,8 @@ export function CalEmbed({
           href={calUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-[var(--text-muted)] hover:text-[var(--primary)] transition-colors"
+          className="transition-colors hover:opacity-80"
+          style={{ color: colors.textMuted }}
           title="Open in new tab"
         >
           <ExternalLink className="w-4 h-4" />
@@ -96,21 +113,36 @@ export function CalEmbed({
       {/* Calendar Body */}
       <div className="min-h-[500px] relative">
         {isLoading && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--background)]">
-            <Loader2 className="w-8 h-8 text-[var(--primary)] animate-spin mb-3" />
-            <p className="text-sm text-[var(--text-muted)]">
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center"
+            style={{ background: colors.bg }}
+          >
+            <Loader2
+              className="w-8 h-8 animate-spin mb-3"
+              style={{ color: colors.accent }}
+            />
+            <p className="text-sm" style={{ color: colors.textMuted }}>
               Loading calendar...
             </p>
           </div>
         )}
 
         {hasError && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--background)] p-6 text-center">
-            <Calendar className="w-12 h-12 text-[var(--text-muted)] mb-4" />
-            <h3 className="text-lg font-semibold text-[var(--text)] mb-2">
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center"
+            style={{ background: colors.bg }}
+          >
+            <Calendar
+              className="w-12 h-12 mb-4"
+              style={{ color: colors.textMuted }}
+            />
+            <h3
+              className="text-lg font-semibold mb-2"
+              style={{ color: colors.text }}
+            >
               Unable to load calendar
             </h3>
-            <p className="text-[var(--text-muted)] mb-4 max-w-sm">
+            <p className="mb-4 max-w-sm" style={{ color: colors.textMuted }}>
               The scheduling widget couldn&apos;t be loaded. You can still book
               directly.
             </p>
@@ -118,7 +150,12 @@ export function CalEmbed({
               href={calUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] bg-[var(--surface)] text-[var(--text)] rounded-lg hover:border-[var(--primary)] hover:text-[var(--primary)] transition-colors font-mono text-sm"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-colors font-mono text-sm hover:opacity-80"
+              style={{
+                border: `1px solid ${colors.border}`,
+                background: colors.surface,
+                color: colors.text,
+              }}
             >
               <Calendar className="w-4 h-4" />
               Open Calendar

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -11,9 +11,21 @@ import {
 } from '@/schemas/contact.schema'
 import { motion, AnimatePresence } from 'framer-motion'
 
+/** Theme colors passed from parent component */
+export interface ThemeColors {
+  accent: string
+  bg: string
+  surface: string
+  text: string
+  textMuted: string
+  border: string
+}
+
 interface ContactFormProps {
   /** Cloudflare Turnstile site key */
   turnstileSiteKey: string
+  /** Theme colors from CMS config */
+  colors: ThemeColors
   /** API endpoint for form submission */
   apiEndpoint?: string
 }
@@ -31,6 +43,7 @@ type FormStatus = 'idle' | 'submitting' | 'success' | 'error'
  */
 export function ContactForm({
   turnstileSiteKey,
+  colors,
   apiEndpoint = '/api/v1/contact',
 }: ContactFormProps) {
   const [status, setStatus] = useState<FormStatus>('idle')
@@ -100,15 +113,24 @@ export function ContactForm({
   }
 
   return (
-    <div className="rounded-xl border border-[var(--color-border)] overflow-hidden bg-[var(--background)]">
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: `1px solid ${colors.border}`, background: colors.bg }}
+    >
       {/* Terminal Header */}
-      <div className="flex items-center gap-2 px-4 py-3 bg-[var(--surface)] border-b border-[var(--color-border)]">
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{
+          background: colors.surface,
+          borderBottom: `1px solid ${colors.border}`,
+        }}
+      >
         <div className="flex gap-1.5">
           <span className="w-3 h-3 rounded-full bg-red-500" />
           <span className="w-3 h-3 rounded-full bg-yellow-500" />
           <span className="w-3 h-3 rounded-full bg-green-500" />
         </div>
-        <span className="text-sm text-[var(--text-muted)] font-mono">
+        <span className="text-sm font-mono" style={{ color: colors.textMuted }}>
           send-message.sh
         </span>
       </div>
@@ -124,16 +146,23 @@ export function ContactForm({
               exit={{ opacity: 0, y: -10 }}
               className="flex flex-col items-center justify-center py-12 text-center"
             >
-              <CheckCircle2 className="w-16 h-16 text-green-500 mb-4" />
-              <h3 className="text-xl font-semibold text-[var(--text)] mb-2">
+              <CheckCircle2
+                className="w-16 h-16 mb-4"
+                style={{ color: colors.accent }}
+              />
+              <h3
+                className="text-xl font-semibold mb-2"
+                style={{ color: colors.text }}
+              >
                 Message Sent!
               </h3>
-              <p className="text-[var(--text-muted)] mb-6">
+              <p className="mb-6" style={{ color: colors.textMuted }}>
                 Thank you for reaching out. I&apos;ll get back to you soon.
               </p>
               <button
                 onClick={() => setStatus('idle')}
-                className="px-4 py-2 text-sm font-medium text-[var(--primary)] hover:underline"
+                className="px-4 py-2 text-sm font-medium hover:underline"
+                style={{ color: colors.accent }}
               >
                 Send another message
               </button>
@@ -159,15 +188,23 @@ export function ContactForm({
 
               {/* Name Field */}
               <div>
-                <label className="flex items-center gap-2 text-sm font-mono text-[var(--text-muted)] mb-2">
-                  <span className="text-[var(--primary)]">$</span>
+                <label
+                  className="flex items-center gap-2 text-sm font-mono mb-2"
+                  style={{ color: colors.textMuted }}
+                >
+                  <span style={{ color: colors.accent }}>$</span>
                   name
                 </label>
                 <input
                   type="text"
                   {...register('name')}
                   placeholder="Your Name"
-                  className="w-full px-4 py-3 rounded-lg bg-[var(--surface)] border border-[var(--color-border)] text-[var(--text)] placeholder:text-[var(--text-muted)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/50 focus:border-[var(--primary)] transition-all"
+                  className="w-full px-4 py-3 rounded-lg focus:outline-none focus:ring-2 transition-all"
+                  style={{
+                    background: colors.surface,
+                    border: `1px solid ${colors.border}`,
+                    color: colors.text,
+                  }}
                 />
                 {errors.name && (
                   <p className="mt-1 text-sm text-red-500">
@@ -178,15 +215,23 @@ export function ContactForm({
 
               {/* Email Field */}
               <div>
-                <label className="flex items-center gap-2 text-sm font-mono text-[var(--text-muted)] mb-2">
-                  <span className="text-[var(--primary)]">$</span>
+                <label
+                  className="flex items-center gap-2 text-sm font-mono mb-2"
+                  style={{ color: colors.textMuted }}
+                >
+                  <span style={{ color: colors.accent }}>$</span>
                   email
                 </label>
                 <input
                   type="email"
                   {...register('email')}
                   placeholder="you@example.com"
-                  className="w-full px-4 py-3 rounded-lg bg-[var(--surface)] border border-[var(--color-border)] text-[var(--text)] placeholder:text-[var(--text-muted)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/50 focus:border-[var(--primary)] transition-all"
+                  className="w-full px-4 py-3 rounded-lg focus:outline-none focus:ring-2 transition-all"
+                  style={{
+                    background: colors.surface,
+                    border: `1px solid ${colors.border}`,
+                    color: colors.text,
+                  }}
                 />
                 {errors.email && (
                   <p className="mt-1 text-sm text-red-500">
@@ -197,15 +242,23 @@ export function ContactForm({
 
               {/* Subject Field */}
               <div>
-                <label className="flex items-center gap-2 text-sm font-mono text-[var(--text-muted)] mb-2">
-                  <span className="text-[var(--primary)]">$</span>
+                <label
+                  className="flex items-center gap-2 text-sm font-mono mb-2"
+                  style={{ color: colors.textMuted }}
+                >
+                  <span style={{ color: colors.accent }}>$</span>
                   subject
                 </label>
                 <input
                   type="text"
                   {...register('subject')}
                   placeholder="Project Inquiry"
-                  className="w-full px-4 py-3 rounded-lg bg-[var(--surface)] border border-[var(--color-border)] text-[var(--text)] placeholder:text-[var(--text-muted)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/50 focus:border-[var(--primary)] transition-all"
+                  className="w-full px-4 py-3 rounded-lg focus:outline-none focus:ring-2 transition-all"
+                  style={{
+                    background: colors.surface,
+                    border: `1px solid ${colors.border}`,
+                    color: colors.text,
+                  }}
                 />
                 {errors.subject && (
                   <p className="mt-1 text-sm text-red-500">
@@ -216,10 +269,13 @@ export function ContactForm({
 
               {/* Message Field */}
               <div>
-                <label className="flex items-center gap-2 text-sm font-mono text-[var(--text-muted)] mb-2">
-                  <span className="text-[var(--primary)]">$</span>
+                <label
+                  className="flex items-center gap-2 text-sm font-mono mb-2"
+                  style={{ color: colors.textMuted }}
+                >
+                  <span style={{ color: colors.accent }}>$</span>
                   message{' '}
-                  <span className="text-[var(--text-muted)]/60">
+                  <span style={{ color: colors.textMuted, opacity: 0.6 }}>
                     &lt;&lt; EOF
                   </span>
                 </label>
@@ -227,7 +283,12 @@ export function ContactForm({
                   {...register('message')}
                   rows={5}
                   placeholder="Tell me about your project or idea..."
-                  className="w-full px-4 py-3 rounded-lg bg-[var(--surface)] border border-[var(--color-border)] text-[var(--text)] placeholder:text-[var(--text-muted)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/50 focus:border-[var(--primary)] transition-all resize-none"
+                  className="w-full px-4 py-3 rounded-lg focus:outline-none focus:ring-2 transition-all resize-none"
+                  style={{
+                    background: colors.surface,
+                    border: `1px solid ${colors.border}`,
+                    color: colors.text,
+                  }}
                 />
                 {errors.message && (
                   <p className="mt-1 text-sm text-red-500">
@@ -271,7 +332,12 @@ export function ContactForm({
               <button
                 type="submit"
                 disabled={status === 'submitting' || !isValid}
-                className="w-full flex items-center justify-center gap-2 px-6 py-3 border border-[var(--color-border)] bg-[var(--surface)] text-[var(--text)] rounded-lg hover:border-[var(--primary)] hover:text-[var(--primary)] disabled:opacity-50 disabled:cursor-not-allowed transition-all font-mono"
+                className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-all font-mono"
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  background: colors.surface,
+                  color: colors.text,
+                }}
               >
                 {status === 'submitting' ? (
                   <>

--- a/src/components/contact/index.ts
+++ b/src/components/contact/index.ts
@@ -7,5 +7,5 @@
  * @module components/contact
  */
 
-export { ContactForm } from './ContactForm'
+export { ContactForm, type ThemeColors } from './ContactForm'
 export { CalEmbed } from './CalEmbed'

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -17,7 +17,7 @@ import { Section } from '@/components/ui/Section'
 import { Container } from '@/components/ui/Container'
 import { Stack } from '@/components/ui/Stack'
 import { Flex } from '@/components/ui/Flex'
-import { ContactForm, CalEmbed } from '@/components/contact'
+import { ContactForm, CalEmbed, type ThemeColors } from '@/components/contact'
 
 interface ContactSectionProps {
   data: CVData
@@ -25,6 +25,8 @@ interface ContactSectionProps {
   turnstileSiteKey?: string
   /** Cal.com username for scheduling */
   calLink?: string
+  /** Theme colors from CMS config */
+  colors: ThemeColors
 }
 
 type ContactTab = 'message' | 'schedule'
@@ -42,6 +44,7 @@ export default function ContactSection({
   data,
   turnstileSiteKey,
   calLink,
+  colors,
 }: ContactSectionProps) {
   const { personalInfo } = data
   const [activeTab, setActiveTab] = useState<ContactTab>('message')
@@ -233,12 +236,15 @@ export default function ContactSection({
               <div className="text-left">
                 {showContactForm && turnstileSiteKey && (
                   <div className={activeTab !== 'message' ? 'hidden' : ''}>
-                    <ContactForm turnstileSiteKey={turnstileSiteKey} />
+                    <ContactForm
+                      turnstileSiteKey={turnstileSiteKey}
+                      colors={colors}
+                    />
                   </div>
                 )}
                 {showCalendar && calLink && (
                   <div className={activeTab !== 'schedule' ? 'hidden' : ''}>
-                    <CalEmbed calLink={calLink} />
+                    <CalEmbed calLink={calLink} colors={colors} />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Contact form and calendar components were showing blue colors instead of the CMS-configured emerald theme
- Root cause: Components used CSS variables from `tokens.css` (hardcoded blue `#3b82f6`) instead of the CMS `themeConfig` colors
- Added `ThemeColors` interface and `colors` prop to contact components
- Updated all styling from CSS variables to inline styles using theme colors

## Test plan
- [ ] Verify contact form displays emerald accent colors (not blue)
- [ ] Verify calendar embed displays emerald accent colors
- [ ] Test both light and dark themes
- [ ] Verify form submission still works